### PR TITLE
Add Deployment onto Kubernetes(minikube) steps using Eclipse JKube

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -18,7 +18,12 @@ image::album-page.png[Album]
 
 |===
 
-== Runnning
+== Running
+
+- <<#docker-using-docker-compose,Docker using Docker Compose>>
+- <<#kubernetes-using-eclipse-jkube,Kubernetes using Eclipse JKube>>
+
+=== Docker using Docker Compose
 
 If you only want to try the application without modifying it, run the build and start the components with `docker-compose`.
 
@@ -67,4 +72,101 @@ Then it's easy to create a script for Flyway.
 [source,shell]
 ----
 docker exec musicstore-db pg_dump -a --inserts --exclude-table=schema_version -h 127.0.0.1 -U music musicdb > src/main/resources/db/migration/V2__InsertData.sql
+----
+
+=== Kubernetes using Eclipse JKube
+You can deploy this application using https://github.com/eclipse/jkube[Eclipse JKube]'s Kubernetes Maven Plugin on top of Kubernetes easily. To do that, you would first need to add it inside plugins section of `pom.xml`. Here is an example of deploying application on https://kubernetes.io/docs/tasks/tools/install-minikube/[minikube]:
+
+==== Setting Database
+Since this application depends on PostgreSQL and MongoDB databases running, we would first deploy these databases onto Kubernetes by applying their YAML manifests which are present inside `kubernetes/` folder:
+
+[source]
+----
+~/work/repos/vertx-musicstore : $ kubectl create -f kubernetes/postgres.yml
+configmap/postgres-config created
+persistentvolume/postgres-pv-volume created
+persistentvolumeclaim/postgres-pv-claim created
+deployment.apps/postgres created
+service/postgres created
+~/work/repos/vertx-musicstore : $ kubectl create -f kubernetes/mongodb.yml
+deployment.apps/mongodb created
+service/mongo created
+----
+Once these are applied you can check whether you are able to connect like this:
+
+[source]
+----
+~/work/repos/vertx-musicstore : $ psql -h `minikube ip` \
+>  -p `kubectl get svc postgres -o jsonpath="{.spec.ports[0].nodePort}"` -U postgresadmin postgresdb
+Password for user postgresadmin:
+psql (12.3, server 10.4 (Debian 10.4-2.pgdg90+1))
+Type "help" for help.
+
+postgresdb=#
+----
+You can check for MongoDB in the same way.
+
+Once our databases are running we need to modify code in order to connect them to databases running inside Kubernetes Cluster.
+
+For PostgreSQL config, we would edit `DatasourceConfig` like this:
+
+[source]
+----
+public DatasourceConfig(JsonObject datasourceConfig) {
+  url = datasourceConfig.getString("url", "jdbc:postgresql://192.168.39.145:31892/musicdb");
+  user = datasourceConfig.getString("user", "postgresadmin");
+  password = datasourceConfig.getString("password", "admin123");
+}
+----
+
+For MongoDB config, we would edit `MusicStoreVerticle` like this:
+
+[source]
+----
+String connectionString = config()
+  .getJsonObject("mongo", new JsonObject())
+  .getString("url", "mongodb://192.168.39.145:31609");
+----
+
+==== Deploying onto Kubernetes using Eclipse JKube
+
+We're using https://kubernetes.io/docs/tasks/tools/install-minikube/[minikube] for our demonstration here, we need to expose minikube's docker daemon. To do this run `eval $(minikube docker-env)`.
+
+We need to delete the `Dockerfile` present inside root folder for Docker Compose since it might be picked up by Eclipse JKube during `k8s:build`. Once deleted we can proceed deploying application:
+
+- Build Application:
+[source]
+----
+mvn clean install
+----
+- Run Eclipse JKube goals to deploy to Kubernetes:
+[source]
+----
+mvn k8s:build    \ # Generate Docker Image
+    k8s:resource \ # Generate Kubernetes manifests
+    k8s:apply    \ # Apply generated Kubernetes Manifests
+    -Pkubernetes \ # Kubernetes Profile
+----
+- Access your application running inside Kubernetes using `minikube service`:
+
+[source]
+----
+~/work/repos/vertx-musicstore : $ kubectl get pods
+NAME                         READY   STATUS    RESTARTS   AGE
+mongodb-855bf5d4db-c8sq4     1/1     Running   0          21m
+musicstore-79b7f45f6-zvv8q   1/1     Running   0          8s
+postgres-7ffd788bc9-g57xp    1/1     Running   0          16m
+~/work/repos/vertx-musicstore : $ kubectl get svc
+NAME         TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)           AGE
+kubernetes   ClusterIP   10.96.0.1       <none>        443/TCP           16d
+mongo        NodePort    10.104.48.6     <none>        27017:31609/TCP   21m
+musicstore   NodePort    10.109.54.16    <none>        8080:30123/TCP    12s
+postgres     NodePort    10.109.76.159   <none>        5432:31892/TCP    17m
+~/work/repos/vertx-musicstore : $ minikube service musicstore
+|-----------|------------|-------------|-----------------------------|
+| NAMESPACE |    NAME    | TARGET PORT |             URL             |
+|-----------|------------|-------------|-----------------------------|
+| default   | musicstore | http/8080   | http://192.168.39.145:30123 |
+|-----------|------------|-------------|-----------------------------|
+🎉  Opening service default/musicstore in default browser...
 ----

--- a/kubernetes/mongodb.yml
+++ b/kubernetes/mongodb.yml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mongodb
+spec:
+  selector:
+    matchLabels:
+      app: mongodb          
+  template:
+    metadata:
+      labels:
+        app: mongodb
+    spec:
+      containers:
+      - name: mongodb
+        image: mongo
+        ports:
+        - name: mongodbport
+          containerPort: 27017
+          protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongo
+  labels:
+    app: mongodb
+spec:
+  type: NodePort
+  ports:
+    - port: 27017
+  selector:
+    app: mongodb          

--- a/kubernetes/postgres.yml
+++ b/kubernetes/postgres.yml
@@ -1,0 +1,85 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-config
+  labels:
+    app: postgres
+data:
+  POSTGRES_DB: postgresdb
+  POSTGRES_USER: postgresadmin
+  POSTGRES_PASSWORD: admin123
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: postgres-pv-volume
+  labels:
+    type: local
+    app: postgres
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteMany
+  hostPath:
+    path: "/mnt/data"
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: postgres-pv-claim
+  labels:
+    app: postgres
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:10.4
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 5432
+          envFrom:
+            - configMapRef:
+                name: postgres-config
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: postgredb
+      volumes:
+        - name: postgredb
+          persistentVolumeClaim:
+            claimName: postgres-pv-claim
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  type: NodePort
+  ports:
+   - port: 5432
+  selector:
+   app: postgres

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,9 @@
     <vertx-stack.version>3.8.1</vertx-stack.version>
     <!-- Vert.x Main Verticle which will be used to start the application -->
     <vertx.verticle>io.vertx.demo.musicstore.MusicStoreVerticle</vertx.verticle>
+    <!-- Eclipse JKube -->
+    <jkube.version>1.0.0-rc-1</jkube.version>
+    <jkube.enricher.jkube-service.type>NodePort</jkube.enricher.jkube-service.type>
   </properties>
 
   <dependencyManagement>
@@ -139,5 +142,20 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>kubernetes</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.eclipse.jkube</groupId>
+            <artifactId>kubernetes-maven-plugin</artifactId>
+            <version>${jkube.version}</version>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>


### PR DESCRIPTION
We can deploy this Vert.x application onto Kubernetes with the help of [Eclipse JKube](https://github.com/eclipse/jkube).
+ Added Eclipse JKube's [kubernetes-maven-plugin](https://search.maven.org/search?q=g:%22org.eclipse.jkube%22%20AND%20a:%22kubernetes-maven-plugin%22) in kubernetes profile
+ Added documentation in README on how to setup databases on Kubernetes and deploy using Eclipse JKube