### PR TITLE
Make docker-compose up more robust

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,32 @@
 FROM openjdk:8-jre-alpine
 
-RUN apk add --update curl && rm -rf /var/cache/apk/*
-
 ENV APP_HOME /opt/vertx-musicstore
 ENV APP_SCRIPT start.sh
 ENV APP_FILE vertx-musicstore.jar
 ENV APP_CONF conf.json
 
+ENV POSTGRES_HOST postgres
+ENV POSTGRES_PORT 5432
+ENV MONGO_HOST mongo
+ENV MONGO_PORT 27017
+
+ENV DOCKERIZE_VERSION v0.6.1
+
 EXPOSE 8080
 
 COPY src/main/docker/$APP_SCRIPT $APP_HOME/
 COPY target/$APP_FILE $APP_HOME/
-COPY src/main/docker/$APP_CONF $APP_HOME/
+COPY src/main/docker/$APP_CONF.tpl $APP_HOME/
+
+RUN set -eux; \
+    apk add --no-cache --update curl; \
+# Install dockerize, see https://github.com/jwilder/dockerize
+    wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz; \
+    tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz; \
+    rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
 WORKDIR $APP_HOME
 
 ENTRYPOINT ["sh", "-c"]
 CMD ["$APP_HOME/$APP_SCRIPT"]
+

--- a/src/main/docker/conf.json
+++ b/src/main/docker/conf.json
@@ -1,8 +1,0 @@
-{
-  "database": {
-    "host": "postgres"
-  },
-  "mongo": {
-    "url": "mongodb://mongo"
-  }
-}

--- a/src/main/docker/conf.json.tpl
+++ b/src/main/docker/conf.json.tpl
@@ -1,0 +1,9 @@
+{
+  "database": {
+    "host": "{{ .Env.POSTGRES_HOST }}",
+    "port": {{ .Env.POSTGRES_PORT }}
+  },
+  "mongo": {
+    "url": "mongodb://{{ .Env.MONGO_HOST }}:{{ .Env.MONGO_PORT }}"
+  }
+}

--- a/src/main/docker/start.sh
+++ b/src/main/docker/start.sh
@@ -1,3 +1,8 @@
 #!/bin/sh
-
-exec java -Dvertx.disableDnsResolver=true -jar ${APP_FILE} -conf ${APP_CONF}
+set -eu
+JAVA_OPTS="-Dvertx.disableDnsResolver=true ${JAVA_OPTS:-}"
+exec dockerize \
+  -wait tcp://${POSTGRES_HOST}:${POSTGRES_PORT} \
+  -wait tcp://${MONGO_HOST}:${MONGO_PORT} \
+  -template "${APP_CONF}.tpl:${APP_CONF}" \
+  java ${JAVA_OPTS} -jar "${APP_FILE}" -conf "${APP_CONF}"


### PR DESCRIPTION
* Added the `dockerize` wrapper to wait until PostgreSQL and MongoDB are
up and ready before starting the application. This avoids the
application failing to start because it cannot connect to the database.

* Make PostgreSQL and MongoDB host and port configurable.

* Accept custom `JAVA_OPTS`.